### PR TITLE
Add __eq__ for Convert and UnaryOp

### DIFF
--- a/ailment/analyses/block_simplifier.py
+++ b/ailment/analyses/block_simplifier.py
@@ -35,6 +35,8 @@ class BlockSimplifier(Analysis):
         ctr = 0
         max_ctr = 30
 
+        block = self._eliminate_dead_assignments(block)
+
         while True:
             ctr += 1
             # print(str(block))

--- a/ailment/expression.py
+++ b/ailment/expression.py
@@ -110,7 +110,6 @@ class Register(Atom):
         return str(self)
 
     def __str__(self):
-        if self.variable is None:
         if hasattr(self, 'reg_name'):
             return "%s<%d>" % (self.reg_name, self.bits // 8)
         if self.variable is None:

--- a/ailment/expression.py
+++ b/ailment/expression.py
@@ -111,10 +111,10 @@ class Register(Atom):
 
     def __str__(self):
         if self.variable is None:
-            if hasattr(self, 'reg_name'):
-                return "%s<%d>" % (self.reg_name, self.bits // 8)
-            else:
-                return "reg_%d<%d>" % (self.reg_offset, self.bits // 8)
+        if hasattr(self, 'reg_name'):
+            return "%s<%d>" % (self.reg_name, self.bits // 8)
+        if self.variable is None:
+            return "reg_%d<%d>" % (self.reg_offset, self.bits // 8)
         else:
             return "%s" % str(self.variable.name)
 

--- a/ailment/expression.py
+++ b/ailment/expression.py
@@ -146,6 +146,15 @@ class UnaryOp(Op):
     def __repr__(self):
         return str(self)
 
+    def __eq__(self, other):
+        return type(other) is UnaryOp and \
+               self.op == other.op and \
+               self.operand == other.operand and \
+               self.bits == other.bits
+
+    def __hash__(self):
+        return hash((self.op, self.operand, self.bits))
+
     def replace(self, old_expr, new_expr):
         r, replaced_operand = self.operand.replace(old_expr, new_expr)
 
@@ -174,6 +183,17 @@ class Convert(UnaryOp):
 
     def __repr__(self):
         return str(self)
+
+    def __eq__(self, other):
+        return type(other) is Convert and \
+               self.operand == other.operand and \
+               self.from_bits == other.from_bits and \
+               self.to_bits == other.to_bits and \
+               self.bits == other.bits and \
+               self.is_signed == other.is_signed
+
+    def __hash__(self):
+        return hash((self.operand, self.from_bits, self.to_bits, self.bits, self.is_signed))
 
     def replace(self, old_expr, new_expr):
         r, replaced_operand = self.operand.replace(old_expr, new_expr)


### PR DESCRIPTION
- BlockSimplifer will do an infinite recursion(reaching to max iterations finally) when the block contains a ConditionalJump statement, add __eq__ function can fix this issue.
- Doing a dead assignments elimination can remove some artificial registers and Tmp expressions which are unnecessary for AIL can speed up BlockSimplifer!

 