### PR TITLE
Call must have .size when being used as an expr.

### DIFF
--- a/ailment/statement.py
+++ b/ailment/statement.py
@@ -278,6 +278,10 @@ class Call(Expression, Statement):
         return self.ret_expr.bits
 
     @property
+    def size(self):
+        return self.bits // 8
+
+    @property
     def verbose_op(self):
         return "call"
 


### PR DESCRIPTION
This PR fixes https://github.com/angr/angr-management/issues/189.