### PR TITLE
Fix(TaggedObject): Add `__new__` method

### DIFF
--- a/ailment/expression.py
+++ b/ailment/expression.py
@@ -346,7 +346,7 @@ class BinaryOp(Op):
 
         assert len(operands) == 2
         self.operands = operands
-        if self.op.startswith("Cmp"):
+        if self.op is not None and self.op.startswith("Cmp"):
             self.bits = 1
         else:
             self.bits = get_bits(operands[0]) if type(operands[0]) is not int else get_bits(operands[1])

--- a/ailment/tagged_object.py
+++ b/ailment/tagged_object.py
@@ -24,6 +24,11 @@ class TaggedObject:
         except KeyError:
             return super(TaggedObject, self).__getattribute__(item)
 
+    def __new__(cls, *args, **kwargs):
+        self = super().__new__(cls)
+        self.tags = { }
+        return self
+
     def __hash__(self):
         if self._hash is None:
             self._hash = self._hash_core()


### PR DESCRIPTION
Overwrite `__new__` to prevent infinite recursion, which caused by using `__getattr__` without initializing tags.

There is a possible situation:
``` python3
from ailment import Assignment
import copy

stmt = Assignment(0, None, None)
copy.copy(stmt)
```