### PR TITLE
Handle MultiValues as valid expression operands

### DIFF
--- a/ailment/utils.py
+++ b/ailment/utils.py
@@ -1,6 +1,7 @@
 from typing import Union, Optional, TYPE_CHECKING
 
 import claripy
+from angr.storage.memory_mixins.paged_memory.pages.multi_values import MultiValues
 
 if TYPE_CHECKING:
     from .expression import Expression
@@ -12,6 +13,8 @@ def get_bits(expr: Union[claripy.ast.Bits,'Expression',int]) -> Optional[int]:
 
     if isinstance(expr, Expression):
         return expr.bits
+    if isinstance(expr, MultiValues):
+        return get_bits(expr.one_value())
     elif isinstance(expr, claripy.ast.Bits):
         return expr.size()
     elif hasattr(expr, 'bits'):


### PR DESCRIPTION
This is showing up a lot in the mini-megatests. I'm not sure if this is correct - are we supposed to be operating on MultiValues here in the first place? but this Seems To Work.