### PR TITLE
fix(TaggedObject): set _tags attribute when creating a new instance

### DIFF
--- a/ailment/tagged_object.py
+++ b/ailment/tagged_object.py
@@ -26,6 +26,24 @@ class TaggedObject:
         except KeyError:
             return super(TaggedObject, self).__getattribute__(item)
 
+    def __new__(cls, *args, **kwargs):
+        """Create a new instance and set `_tags` attribute.
+        
+        Since TaggedObject override `__getattr__` method and try to access the 
+        `_tags` attribute, infinite recursion could be occur if `_tags` not 
+        ready exists. 
+        
+        This behavior causes an infinite recursion error when copying 
+        `TaggedObject` with `copy.deepcopy`.
+
+        Hence, we set `_tags` attribute here to prevent this problem.
+        """
+        # dele unused argument
+        del args, kwargs
+        self = super().__new__(cls)
+        self._tags = None
+        return self
+
     def __hash__(self):
         if self._hash is None:
             self._hash = self._hash_core()

--- a/ailment/tagged_object.py
+++ b/ailment/tagged_object.py
@@ -30,15 +30,15 @@ class TaggedObject:
         """Create a new instance and set `_tags` attribute.
         
         Since TaggedObject override `__getattr__` method and try to access the 
-        `_tags` attribute, infinite recursion could be occur if `_tags` not 
-        ready exists. 
+        `_tags` attribute, infinite recursion could occur if `_tags` not ready 
+        to exists. 
         
         This behavior causes an infinite recursion error when copying 
         `TaggedObject` with `copy.deepcopy`.
 
         Hence, we set `_tags` attribute here to prevent this problem.
         """
-        # dele unused argument
+        # delete unused argument
         del args, kwargs
         self = super().__new__(cls)
         self._tags = None

--- a/ailment/tagged_object.py
+++ b/ailment/tagged_object.py
@@ -24,22 +24,20 @@ class TaggedObject:
         try:
             return self.tags[item]
         except KeyError:
-            return super(TaggedObject, self).__getattribute__(item)
+            return super().__getattribute__(item)
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs):  # pylint:disable=unused-argument
         """Create a new instance and set `_tags` attribute.
-        
-        Since TaggedObject override `__getattr__` method and try to access the 
-        `_tags` attribute, infinite recursion could occur if `_tags` not ready 
-        to exists. 
-        
-        This behavior causes an infinite recursion error when copying 
+
+        Since TaggedObject override `__getattr__` method and try to access the
+        `_tags` attribute, infinite recursion could occur if `_tags` not ready
+        to exists.
+
+        This behavior causes an infinite recursion error when copying
         `TaggedObject` with `copy.deepcopy`.
 
         Hence, we set `_tags` attribute here to prevent this problem.
         """
-        # delete unused argument
-        del args, kwargs
         self = super().__new__(cls)
         self._tags = None
         return self


### PR DESCRIPTION
Hi, this PR fixes a bug in TaggedObject that infinite recursion could occur if `_tags` are not ready to exist. 

In my practice, this bug affects a lot since the deep copy method is not implemented in ailment and `copy.deepcopy` failed with infinite recursion error.

A stale PR I created earlier: https://github.com/angr/ailment/pull/62